### PR TITLE
Update fpu.yar

### DIFF
--- a/malware_analysis/FPU/fpu.yar
+++ b/malware_analysis/FPU/fpu.yar
@@ -1,3 +1,4 @@
+import "pe"
 rule undocumentedFPUAtEntryPoint {
 strings:
     $fpu1 = {D9 D8}
@@ -7,5 +8,5 @@ strings:
     $fpu5 = {DF DA}
     $fpu6 = {DF CB}
 condition:
-    (for any of ($fpu*) : ($ at entrypoint)) or $fpu2 in (entrypoint..entrypoint + 10)
+    (for any of ($fpu*) : ($ at pe.entry_point)) or $fpu2 in (pe.entry_point..pe.entry_point + 10)
 }


### PR DESCRIPTION
Updated this rule to not use the deprecated version of entrypoint, but to use the recommended approach that yara gives you when you try to run this rule as-is. I do not have a valid sample to test this on, so I cannot confirm whether this breaks detection, but yara no longer gives the warning with these changes in place.